### PR TITLE
Disable per client metrics

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -68,10 +68,15 @@ func Run() error {
 			Usage:    "The OpenVPN status file(s) to export (example test:./example/version1.status )",
 			Required: true,
 		},
+		&cli.BoolFlag{
+			Name:  "disable-client-metrics",
+			Usage: "Disables per client (bytes_received, bytes_sent, connected_since) metrics",
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {
-		cfg.StatusFile = c.StringSlice("status-file")
+		cfg.StatusCollector.StatusFile = c.StringSlice("status-file")
+		cfg.StatusCollector.ExportClientMetrics = !c.Bool("disable-client-metrics")
 		return nil
 	}
 
@@ -105,7 +110,7 @@ func run(c *cli.Context, cfg *config.Config) error {
 		version.GoVersion,
 		version.Started,
 	))
-	for _, statusFile := range cfg.StatusFile {
+	for _, statusFile := range cfg.StatusCollector.StatusFile {
 		serverName, statusFile := parseStatusFileSlice(statusFile)
 
 		level.Info(logger).Log(
@@ -117,6 +122,7 @@ func run(c *cli.Context, cfg *config.Config) error {
 			logger,
 			serverName,
 			statusFile,
+			cfg.StatusCollector.ExportClientMetrics,
 		))
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,9 +14,15 @@ type Logs struct {
 
 // Config defines the general configuration object
 type Config struct {
-	Server     Server
-	Logs       Logs
-	StatusFile []string
+	Server          Server
+	Logs            Logs
+	StatusCollector StatusCollector
+}
+
+// StatusCollector contains configuration for the OpenVPN status collector
+type StatusCollector struct {
+	ExportClientMetrics bool
+	StatusFile          []string
 }
 
 // Load initializes a default configuration struct.

--- a/pkg/openvpn/parser_test.go
+++ b/pkg/openvpn/parser_test.go
@@ -91,3 +91,29 @@ func TestConnectedClientsParsedCorrectly(t *testing.T) {
 		t.Errorf("Clients are not parsed correctly")
 	}
 }
+
+const badFields = `OpenVPN CLIENT LIST
+Updated,test
+Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since
+user1,1.2.3.4,foo,foo,test
+ROUTING TABLE
+Virtual Address,Common Name,Real Address,Last Ref
+10.240.1.222,user4,1.2.3.7:fooo,test
+GLOBAL STATS
+Max bcast/mcast queue length,foo
+END
+`
+
+func TestParsingWrongValuesIsNotAnIssue(t *testing.T) {
+	status, e := parse(bufio.NewReader(strings.NewReader(badFields)))
+	if e != nil {
+		t.Errorf("should have worked")
+	}
+	if status.GlobalStats.MaxBcastMcastQueueLen != 0 {
+		t.Errorf("Parsing wrong MaxBcastMcastQueueLen value lead to unexpected result")
+	}
+	expectedTime := time.Time{}
+	if !expectedTime.Equal(status.UpdatedAt) {
+		t.Errorf("parsing incorrect time value should have yieleded a default time object")
+	}
+}


### PR DESCRIPTION
# Motivation

On openvpn servers with a lot of connected clients, the cardinality of the `common_name` label can increase a lot. In order to prevent high cardinality issues, we want to be able to optionally disable the metric

# Description

- adds cli flag to easily disable per client metrics