### PR TITLE
refactor: improved the description of openvpn_start_time metric

### DIFF
--- a/pkg/collector/exporter.go
+++ b/pkg/collector/exporter.go
@@ -38,7 +38,7 @@ func NewGeneralCollector(logger log.Logger, version string, revision string, bui
 
 		StartTime: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "start_time"),
-			"Unix timestamp of the start time",
+			"Unix timestamp of the start time of the exporter",
 			nil,
 			nil,
 		),


### PR DESCRIPTION
the label should reflect, that the start time is from the exporter
itself and does not reflect the server start/uptime