### PR TITLE
Fix registering several servers for scraping

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -84,6 +84,13 @@ func Run() error {
 			EnvVars:     []string{"OPENVPN_EXPORTER_ENABLE_GOLANG_METRICS"},
 			Destination: &cfg.ExportGoMetrics,
 		},
+		&cli.StringFlag{
+			Name:        "log.level",
+			Value:       "info",
+			Usage:       "Only log messages with given severity",
+			EnvVars:     []string{"OPENVPN_EXPORTER_LOG_LEVEL"},
+			Destination: &cfg.Logs.Level,
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {


### PR DESCRIPTION
# Description

When starting the server with several status files, the exporter would panic as we tried to register a duplicated collector

```
panic: duplicate metrics collector registration attempted

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc000020280, 0xc000247d00, 0x1, 0x1)
```

This refactors it, so that we only have one collector registered and iterate over the different openvpn server during collection time