### PR TITLE
fix: panic when more than a single common name is found

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.27
+          version: v1.33
       - name: Build release type artifacts
         run: make release

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,7 +18,7 @@ jobs:
           make test
           make build
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           version: v1.33
       - name: Build release type artifacts

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ release-build:
 	@which gox > /dev/null; if [ $$? -ne 0 ]; then \
 		GO111MODULE=off  $(GO) get -u github.com/mitchellh/gox; \
 	fi
-	gox -arch="386 amd64 arm" -verbose -ldflags '-w $(LDFLAGS)' -output="$(DIST)/$(EXECUTABLE)-{{.OS}}-{{.Arch}}" ./cmd/$(NAME)
+	gox -arch="386 amd64 arm" -osarch '!darwin/386' -verbose -ldflags '-w $(LDFLAGS)' -output="$(DIST)/$(EXECUTABLE)-{{.OS}}-{{.Arch}}" ./cmd/$(NAME)
 
 .PHONY: release-checksums
 release-checksums:

--- a/example/duplicate.status
+++ b/example/duplicate.status
@@ -1,0 +1,11 @@
+OpenVPN CLIENT LIST
+Updated,Fri Jun  5 09:03:05 2020
+Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since
+foo_foo,::ffff:1.1.1.1,898582,674355,Thu Jun  4 08:50:24 2020
+bar_bar,::ffff:2.2.2.2,1550890,1156181,Wed Jun  3 14:00:04 2020
+bar_bar,::ffff:2.2.2.2,1550890,1156181,Wed Jun  3 14:00:04 2020
+UNDEF,::ffff:3.3.3.3,527,10441,Fri Jun  5 09:02:17 2020
+UNDEF,::ffff:4.4.4.4,527,8830,Fri Jun  5 09:02:39 2020
+GLOBAL STATS
+Max bcast/mcast queue length,0
+END

--- a/pkg/collector/openvpn_test.go
+++ b/pkg/collector/openvpn_test.go
@@ -1,0 +1,23 @@
+package collector
+
+import "testing"
+
+var containsTestCases = []struct {
+	scenarioName string
+	list         []string
+	element      string
+	expected     bool
+}{
+	{"contains element", []string{"bar", "foo"}, "bar", true},
+	{"does not contain element", []string{"foo", "bar"}, "baz", false},
+}
+
+func TestContainsFunction(t *testing.T) {
+	for _, tt := range containsTestCases {
+		t.Run(tt.scenarioName, func(t *testing.T) {
+			if contains(tt.list, tt.element) != tt.expected {
+				t.Errorf("Unexpected result")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Motivation

Prevent the exporter from panicking when the status file contains duplicate common names

# Description

Track the client common names and drop metrics when a second client is encountered. 
A warning in the log file will appear when the issues occurs

related to #15 