### PR TITLE
Add allow-duplicate-cn command-line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ GLOBAL OPTIONS:
    --web.root value                                 Root path to exporter endpoints (default: "/") [$OPENVPN_EXPORTER_WEB_ROOT]
    --status-file value                              The OpenVPN status file(s) to export (example test:./example/version1.status ) [$OPENVPN_EXPORTER_STATUS_FILE]
    --disable-client-metrics                         Disables per client (bytes_received, bytes_sent, connected_since) metrics (default: false) [$OPENVPN_EXPORTER_DISABLE_CLIENT_METRICS]
+   --allow-duplicate-cn                             Allow multiple connections with the same common name distinguished by the Client ID (only works with version 2 and 3 status types) (default: false) [$OPENVPN_EXPORTER_ALLOW_DUPLICATE_CN]
    --enable-golang-metrics                          Enables golang and process metrics for the exporter)  (default: false) [$OPENVPN_EXPORTER_ENABLE_GOLANG_METRICS]
    --log.level value                                Only log messages with given severity (default: "info") [$OPENVPN_EXPORTER_LOG_LEVEL]
    --help, -h                                       Show help (default: false)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GLOBAL OPTIONS:
    --web.root value                                 Root path to exporter endpoints (default: "/") [$OPENVPN_EXPORTER_WEB_ROOT]
    --status-file value                              The OpenVPN status file(s) to export (example test:./example/version1.status ) [$OPENVPN_EXPORTER_STATUS_FILE]
    --disable-client-metrics                         Disables per client (bytes_received, bytes_sent, connected_since) metrics (default: false) [$OPENVPN_EXPORTER_DISABLE_CLIENT_METRICS]
-   --allow-duplicate-cn                             Allow multiple connections with the same common name distinguished by the Client ID (only works with version 2 and 3 status types) (default: false) [$OPENVPN_EXPORTER_ALLOW_DUPLICATE_CN]
+   --allow-duplicate-cn                             Allow multiple connections with the same common name distinguished by the Peer ID (only works with version 2 and 3 status types) (default: false) [$OPENVPN_EXPORTER_ALLOW_DUPLICATE_CN]
    --enable-golang-metrics                          Enables golang and process metrics for the exporter)  (default: false) [$OPENVPN_EXPORTER_ENABLE_GOLANG_METRICS]
    --log.level value                                Only log messages with given severity (default: "info") [$OPENVPN_EXPORTER_LOG_LEVEL]
    --help, -h                                       Show help (default: false)

--- a/example/version2.status
+++ b/example/version2.status
@@ -2,7 +2,8 @@ TITLE,OpenVPN 2.4.4 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKC
 TIME,Thu Apr 30 13:55:44 2020,1588254944
 HEADER,CLIENT_LIST,Common Name,Real Address,Virtual Address,Virtual IPv6 Address,Bytes Received,Bytes Sent,Connected Since,Connected Since (time_t),Username,Client ID,Peer ID
 CLIENT_LIST,test@localhost,1.2.3.4:54190,10.80.0.65,,3860,3688,Thu Apr 30 13:55:38 2020,1588254938,test@localhost,0,0
-CLIENT_LIST,test1@localhost,1.2.3.5:51053,10.68.0.25,,3871,3924,Thu Apr 30 13:55:40 2020,1588254940,test1@localhost,1,1
+CLIENT_LIST,test@localhost,1.2.3.4:54190,10.80.0.65,,3860,3688,Thu Apr 30 13:55:38 2020,1588254938,test@localhost,1,1
+CLIENT_LIST,test1@localhost,1.2.3.5:51053,10.68.0.25,,3871,3924,Thu Apr 30 13:55:40 2020,1588254940,test1@localhost,2,2
 HEADER,ROUTING_TABLE,Virtual Address,Common Name,Real Address,Last Ref,Last Ref (time_t)
 ROUTING_TABLE,10.80.0.65,test@localhost,1.2.3.4:54190,Thu Apr 30 13:55:40 2020,1588254940
 ROUTING_TABLE,10.68.0.25,test1@localhost,1.2.3.5:51053,Thu Apr 30 13:55:42 2020,1588254942

--- a/example/version3.status
+++ b/example/version3.status
@@ -2,7 +2,8 @@ TITLE	OpenVPN 2.4.4 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKC
 TIME	Thu Apr 30 13:55:44 2020	1588254944
 HEADER	CLIENT_LIST	Common Name	Real Address	Virtual Address	Virtual IPv6 Address	Bytes Received	Bytes Sent	Connected Since	Connected Since (time_t)	Username	Client ID	Peer ID
 CLIENT_LIST	test@localhost	1.2.3.4:54190	10.80.0.65		3860	3688	Thu Apr 30 13:55:38 2020	1588254938	test@localhost	0	0
-CLIENT_LIST	test1@localhost	1.2.3.5:51053	10.68.0.25		3871	3924	Thu Apr 30 13:55:40 2020	1588254940	test1@localhost	1	1
+CLIENT_LIST	test@localhost	1.2.3.4:54190	10.80.0.65		3860	3688	Thu Apr 30 13:55:38 2020	1588254938	test@localhost	1	1
+CLIENT_LIST	test1@localhost	1.2.3.5:51053	10.68.0.25		3871	3924	Thu Apr 30 13:55:40 2020	1588254940	test1@localhost	2	2
 HEADER	ROUTING_TABLE	Virtual Address	Common Name	Real Address	Last Ref	Last Ref (time_t)
 ROUTING_TABLE	10.80.0.65	test@localhost	1.2.3.4:54190	Thu Apr 30 13:55:40 2020	1588254940
 ROUTING_TABLE	10.68.0.25	test1@localhost	1.2.3.5:51053	Thu Apr 30 13:55:42 2020	1588254942

--- a/pkg/collector/openvpn.go
+++ b/pkg/collector/openvpn.go
@@ -61,19 +61,19 @@ func NewOpenVPNCollector(logger log.Logger, openVPNServer []OpenVPNServer, colle
 		BytesReceived: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "bytes_received"),
 			"Amount of data received via the connection",
-			[]string{"server", "common_name", "cid"},
+			[]string{"server", "common_name", "unique_id"},
 			nil,
 		),
 		BytesSent: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "bytes_sent"),
 			"Amount of data sent via the connection",
-			[]string{"server", "common_name", "cid"},
+			[]string{"server", "common_name", "unique_id"},
 			nil,
 		),
 		ConnectedSince: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "connected_since"),
 			"Unixtimestamp when the connection was established",
-			[]string{"server", "common_name", "cid"},
+			[]string{"server", "common_name", "unique_id"},
 			nil,
 		),
 		ServerInfo: prometheus.NewDesc(
@@ -151,7 +151,7 @@ func (c *OpenVPNCollector) collect(ovpn OpenVPNServer, ch chan<- prometheus.Metr
 					)
 					continue
 				}
-				if c.allowDuplicateCn && client.ClientID == -1 {
+				if c.allowDuplicateCn && client.PeerID == -1 {
 					level.Warn(c.logger).Log(
 						"msg", "allow-duplicate-cn flag with a version 1 statusfile - duplicate metric dropped (use version 2 or 3)",
 						"commonName", client.CommonName,
@@ -164,19 +164,19 @@ func (c *OpenVPNCollector) collect(ovpn OpenVPNServer, ch chan<- prometheus.Metr
 				c.BytesReceived,
 				prometheus.CounterValue,
 				client.BytesReceived,
-				ovpn.Name, client.CommonName, strconv.FormatInt(client.ClientID, 10),
+				ovpn.Name, client.CommonName, strconv.FormatInt(client.PeerID, 10),
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.BytesSent,
 				prometheus.CounterValue,
 				client.BytesSent,
-				ovpn.Name, client.CommonName, strconv.FormatInt(client.ClientID, 10),
+				ovpn.Name, client.CommonName, strconv.FormatInt(client.PeerID, 10),
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.ConnectedSince,
 				prometheus.GaugeValue,
 				float64(client.ConnectedSince.Unix()),
-				ovpn.Name, client.CommonName, strconv.FormatInt(client.ClientID, 10),
+				ovpn.Name, client.CommonName, strconv.FormatInt(client.PeerID, 10),
 			)
 		}
 	}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -79,6 +79,12 @@ func Run() error {
 			EnvVars: []string{"OPENVPN_EXPORTER_DISABLE_CLIENT_METRICS"},
 		},
 		&cli.BoolFlag{
+			Name:        "allow-duplicate-cn",
+			Usage:       "Allow multiple connections with the same common name distinguished by the Client ID (only works with version 2 and 3 status types)",
+			EnvVars:     []string{"OPENVPN_EXPORTER_ALLOW_DUPLICATE_CN"},
+			Destination: &cfg.AllowDuplicateCN,
+		},
+		&cli.BoolFlag{
 			Name:        "enable-golang-metrics",
 			Value:       false,
 			Usage:       "Enables golang and process metrics for the exporter) ",
@@ -145,6 +151,7 @@ func run(cfg *config.Config) error {
 		logger,
 		openVPServers,
 		cfg.StatusCollector.ExportClientMetrics,
+		cfg.AllowDuplicateCN,
 	))
 
 	http.Handle(cfg.Server.Path,

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -80,7 +80,7 @@ func Run() error {
 		},
 		&cli.BoolFlag{
 			Name:        "allow-duplicate-cn",
-			Usage:       "Allow multiple connections with the same common name distinguished by the Client ID (only works with version 2 and 3 status types)",
+			Usage:       "Allow multiple connections with the same common name distinguished by the Peer ID (only works with version 2 and 3 status types)",
 			EnvVars:     []string{"OPENVPN_EXPORTER_ALLOW_DUPLICATE_CN"},
 			Destination: &cfg.AllowDuplicateCN,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,10 +14,11 @@ type Logs struct {
 
 // Config defines the general configuration object
 type Config struct {
-	Server          Server
-	Logs            Logs
-	StatusCollector StatusCollector
-	ExportGoMetrics bool
+	Server           Server
+	Logs             Logs
+	StatusCollector  StatusCollector
+	ExportGoMetrics  bool
+	AllowDuplicateCN bool
 }
 
 // StatusCollector contains configuration for the OpenVPN status collector

--- a/pkg/openvpn/parser.go
+++ b/pkg/openvpn/parser.go
@@ -23,6 +23,7 @@ type Client struct {
 	BytesReceived  float64
 	BytesSent      float64
 	ConnectedSince time.Time
+	ClientID       int64
 }
 
 // ServerInfo reflects information that was collected about the server
@@ -114,6 +115,7 @@ func parseStatusV1(reader io.Reader) (*Status, error) {
 					BytesReceived:  bytesRec,
 					BytesSent:      bytesSent,
 					ConnectedSince: parseTime(fields[4]),
+					ClientID:       -1,
 				}
 				clients = append(clients, client)
 			}
@@ -142,12 +144,14 @@ func parseStatusV2AndV3(reader io.Reader, separator string) (*Status, error) {
 			bytesRec, _ := strconv.ParseFloat(fields[5], 64)
 			bytesSent, _ := strconv.ParseFloat(fields[6], 64)
 			connectedSinceInt, _ := strconv.ParseInt(fields[8], 10, 64)
+			clientIdInt, _ := strconv.ParseInt(fields[10], 10, 64)
 			client := Client{
 				CommonName:     fields[1],
 				RealAddress:    parseIP(fields[2]),
 				BytesReceived:  bytesRec,
 				BytesSent:      bytesSent,
 				ConnectedSince: time.Unix(connectedSinceInt, 0),
+				ClientID:       clientIdInt,
 			}
 			clients = append(clients, client)
 		} else if fields[0] == "GLOBAL_STATS" {

--- a/pkg/openvpn/parser.go
+++ b/pkg/openvpn/parser.go
@@ -23,7 +23,7 @@ type Client struct {
 	BytesReceived  float64
 	BytesSent      float64
 	ConnectedSince time.Time
-	ClientID       int64
+	PeerID       int64
 }
 
 // ServerInfo reflects information that was collected about the server
@@ -115,7 +115,7 @@ func parseStatusV1(reader io.Reader) (*Status, error) {
 					BytesReceived:  bytesRec,
 					BytesSent:      bytesSent,
 					ConnectedSince: parseTime(fields[4]),
-					ClientID:       -1,
+					PeerID:         -1,
 				}
 				clients = append(clients, client)
 			}
@@ -144,14 +144,14 @@ func parseStatusV2AndV3(reader io.Reader, separator string) (*Status, error) {
 			bytesRec, _ := strconv.ParseFloat(fields[5], 64)
 			bytesSent, _ := strconv.ParseFloat(fields[6], 64)
 			connectedSinceInt, _ := strconv.ParseInt(fields[8], 10, 64)
-			clientIdInt, _ := strconv.ParseInt(fields[10], 10, 64)
+			peerIdInt, _ := strconv.ParseInt(fields[11], 10, 64)
 			client := Client{
 				CommonName:     fields[1],
 				RealAddress:    parseIP(fields[2]),
 				BytesReceived:  bytesRec,
 				BytesSent:      bytesSent,
 				ConnectedSince: time.Unix(connectedSinceInt, 0),
-				ClientID:       clientIdInt,
+				PeerID:         peerIdInt,
 			}
 			clients = append(clients, client)
 		} else if fields[0] == "GLOBAL_STATS" {

--- a/pkg/openvpn/parser.go
+++ b/pkg/openvpn/parser.go
@@ -23,7 +23,8 @@ type Client struct {
 	BytesReceived  float64
 	BytesSent      float64
 	ConnectedSince time.Time
-	PeerID       int64
+	ClientID       int64
+	PeerID         int64
 }
 
 // ServerInfo reflects information that was collected about the server
@@ -144,6 +145,7 @@ func parseStatusV2AndV3(reader io.Reader, separator string) (*Status, error) {
 			bytesRec, _ := strconv.ParseFloat(fields[5], 64)
 			bytesSent, _ := strconv.ParseFloat(fields[6], 64)
 			connectedSinceInt, _ := strconv.ParseInt(fields[8], 10, 64)
+			clientIdInt, _ := strconv.ParseInt(fields[10], 10, 64)
 			peerIdInt, _ := strconv.ParseInt(fields[11], 10, 64)
 			client := Client{
 				CommonName:     fields[1],
@@ -151,6 +153,7 @@ func parseStatusV2AndV3(reader io.Reader, separator string) (*Status, error) {
 				BytesReceived:  bytesRec,
 				BytesSent:      bytesSent,
 				ConnectedSince: time.Unix(connectedSinceInt, 0),
+				ClientID:       clientIdInt,
 				PeerID:         peerIdInt,
 			}
 			clients = append(clients, client)


### PR DESCRIPTION
This pull request utilizes the Peer ID to uniquely identify each request, with the lowest cardinality possible. The Peer ID a unique ID for each connection, given by the OpenVPN itself in the log file, which is started from 0 and incremented by each new connection.

The good point of this method is that if any of the old ID's get disconnected, those empty spaces will be filled when someone new connects, this way, this number will almost always remain under the maximum client count of your server, and a cardinality of roughly `n^2` could be expected where `n` is the maximum expected simultaneous client count. It is an opt-in feature, which will get activated by this flag: `--allow-duplicate-cn`.

This fixes #15.